### PR TITLE
Marvin dependency was removed from the Toolkit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,6 @@
 			<version>1.7.12</version>
 		</dependency>
 		<dependency>
-			<groupId>chemaxon</groupId>
-			<artifactId>MarvinBeans</artifactId>
-			<version>5.0</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
 			<version>1.9</version>


### PR DESCRIPTION
Helm2NotationToolkit does not need Marvin dependency. This dependency was delegated to the Chemistry toolkit Marvin plug-in. 
